### PR TITLE
chore: semantic-releaseのリリース成功コメントを無効化

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,6 +10,11 @@
                 "provenance": true
             }
         ],
-        "@semantic-release/github"
+        [
+            "@semantic-release/github",
+            {
+                "successComment": false
+            }
+        ]
     ]
 }


### PR DESCRIPTION
## Summary
- `@semantic-release/github` の `successComment` を `false` に設定し、リリース時に Issue / PR へ自動でコメントが付くのを止める
- `failComment` / `labels` / `releasedLabels` はリリース失敗の気付きやすさのため維持

## Test plan
- [ ] PR の check (typecheck / lint / format:check / test) が green
- [ ] main にマージ後の Release workflow で、リリース成功時に closed Issue / PR にコメントが付かないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)