### PR TITLE
Configure Renovate to manage pnpm version in package.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,17 @@
     "extends": ["config:best-practices"],
     "automerge": true,
     "platformAutomerge": true,
+    "customManagers": [
+        {
+            "customType": "jsonata",
+            "fileFormat": "json",
+            "managerFilePatterns": ["/(^|/)package\\.json$/"],
+            "matchStrings": [
+                "{ \"depName\": devEngines.packageManager.name, \"currentValue\": devEngines.packageManager.version }"
+            ],
+            "datasourceTemplate": "npm"
+        }
+    ],
     "packageRules": [
         {
             "matchPackageNames": ["@swagger-api/apidom-ls"],
@@ -19,6 +30,10 @@
         {
             "matchUpdateTypes": ["major"],
             "automerge": false
+        },
+        {
+            "matchPackageNames": ["pnpm"],
+            "groupName": "pnpm"
         }
     ]
 }


### PR DESCRIPTION
## Summary
This PR enhances the Renovate configuration to automatically detect and manage the pnpm package manager version specified in `package.json` devEngines, enabling automated dependency updates for the package manager itself.

## Key Changes
- Added a custom JSONata manager to parse and track the `devEngines.packageManager.version` field in `package.json`
- Configured the custom manager to use the npm datasource for version resolution
- Added a package rule to group pnpm updates under a single "pnpm" group for better organization

## Implementation Details
The custom manager uses a JSONata expression to extract the package manager name and version from the devEngines configuration in package.json. This allows Renovate to treat the pnpm version as a managed dependency and automatically create pull requests when updates are available, while keeping pnpm updates grouped separately from other dependencies.

https://claude.ai/code/session_01N2KgsLmBPirJG2wG3g9qEd