### PR TITLE
ci: replace @semantic-release/npm with @semantic-release/exec + pnpm

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,9 +5,10 @@
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
         [
-            "@semantic-release/npm",
+            "@semantic-release/exec",
             {
-                "provenance": true
+                "prepareCmd": "pnpm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
+                "publishCmd": "pnpm publish --no-git-checks --provenance --access public"
             }
         ],
         [

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "vscode-languageserver-textdocument": "1.0.12"
     },
     "devDependencies": {
+        "@semantic-release/exec": "7.1.0",
         "@tsconfig/strictest": "2.0.8",
         "@types/node": "24.12.4",
         "npm-run-all2": "8.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
         specifier: 1.0.12
         version: 1.0.12
     devDependencies:
+      '@semantic-release/exec':
+        specifier: 7.1.0
+        version: 7.1.0(semantic-release@25.0.3(typescript@6.0.3))
       '@tsconfig/strictest':
         specifier: 2.0.8
         version: 2.0.8
@@ -643,6 +646,12 @@ packages:
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
     engines: {node: '>=18'}
 
+  '@semantic-release/exec@7.1.0':
+    resolution: {integrity: sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==}
+    engines: {node: '>=20.8.1'}
+    peerDependencies:
+      semantic-release: '>=24.1.0'
+
   '@semantic-release/github@12.0.8':
     resolution: {integrity: sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==}
     engines: {node: ^22.14.0 || >= 24.10.0}
@@ -818,6 +827,10 @@ packages:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
 
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
   aggregate-error@5.0.0:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
@@ -927,6 +940,10 @@ packages:
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   clean-stack@5.3.0:
     resolution: {integrity: sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==}
@@ -1281,6 +1298,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -2556,6 +2577,18 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(typescript@6.0.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.3
+      execa: 9.6.1
+      lodash-es: 4.18.1
+      parse-json: 8.3.0
+      semantic-release: 25.0.3(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@semantic-release/github@12.0.8(semantic-release@25.0.3(typescript@6.0.3))':
     dependencies:
       '@octokit/core': 7.0.6
@@ -3111,6 +3144,11 @@ snapshots:
 
   agent-base@9.0.0: {}
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
   aggregate-error@5.0.0:
     dependencies:
       clean-stack: 5.3.0
@@ -3209,6 +3247,8 @@ snapshots:
   char-regex@1.0.2: {}
 
   citty@0.2.2: {}
+
+  clean-stack@2.2.0: {}
 
   clean-stack@5.3.0:
     dependencies:
@@ -3571,6 +3611,8 @@ snapshots:
       - supports-color
 
   import-meta-resolve@4.2.0: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 


### PR DESCRIPTION
## Summary

- リリースワークフロー（[run #30](https://github.com/eai04191/apidom-validate-cli/actions/runs/25910524558/job/76154230303)）が `npm error code EBADDEVENGINES` で落ちている問題を修正する。
- 原因は `@semantic-release/npm` の `prepare` ステップが内部で `npm version 0.3.0` を実行するが、`package.json` の `devEngines.packageManager` が pnpm を要求している（`onFail: "download"`）ため npm 11 が `Invalid name "pnpm" does not match "npm" for "packageManager"` で拒否すること。`onFail` の "download" は `npm install` のような package-manager-aware なコマンドにしか効かず、`npm version` には適用されない。
- `@semantic-release/npm` を `@semantic-release/exec` に置き換え、`pnpm version` / `pnpm publish` を直接呼ぶ構成に変更。`devEngines.packageManager` の強制（ローカル開発で pnpm を使わせる）を維持したまま CI からのリリースが通るようにする。
- semantic-release プロジェクトには公式の pnpm 用プラグインは無く（[semantic-release/npm#280](https://github.com/semantic-release/npm/issues/280) は 2020 年以来オープン放置）、community plugin を導入せずに公式の `@semantic-release/exec` だけで対応する方針を採用。
- npm Trusted Publishing 経由の provenance は `pnpm publish --provenance` で引き続き付与される。OIDC 用 env (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) は `id-token: write` 権限により自動で渡るので追加のトークン設定は不要。

## Test plan

- [ ] このブランチがマージされた後、main への push で走る Release workflow が成功し v0.3.0（または `feat: ...apidom-ls v1.11.1` 由来の minor バージョン）がリリースされる
- [ ] npmjs.com で provenance attestation が付与された状態で公開されている
- [ ] GitHub Release が作成されている
- [x] ローカルで `pnpm run check`（typecheck / lint / format:check / test）が通る

https://claude.ai/code/session_01JMDpttU4fCVCnWasQNBbVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMDpttU4fCVCnWasQNBbVA)_