### PR TITLE
chore: require 1 day minimum age for apidom-ls updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
             "matchPackageNames": ["@swagger-api/apidom-ls"],
             "semanticCommitType": "feat",
             "semanticCommitScope": "deps",
-            "minimumReleaseAge": null
+            "minimumReleaseAge": "1 days"
         },
         {
             "matchPackageNames": ["@swagger-api/apidom-ls"],


### PR DESCRIPTION
## Summary
Updated the Renovate configuration to enforce a minimum release age for `@swagger-api/apidom-ls` dependency updates, preventing immediate adoption of newly published versions.

## Changes
- Set `minimumReleaseAge` from `null` (no minimum) to `"1 days"` for `@swagger-api/apidom-ls` package
- This ensures the package has been available for at least 1 day before Renovate creates an update PR

## Details
This change adds a safety buffer for the `@swagger-api/apidom-ls` dependency, allowing time for any potential issues with newly released versions to surface before they are automatically updated in this repository. This is a common practice for critical dependencies to reduce the risk of adopting buggy releases.

https://claude.ai/code/session_01GmSZGMY6nh7knfXuuBE9Bh