### PR TITLE
fix(deps): update vscode-languageserver-types to v3.18.0 and handle MarkupContent message

### DIFF
--- a/bin/lib.mjs
+++ b/bin/lib.mjs
@@ -39,12 +39,15 @@ export function formatDiagnostic(diagnostic) {
         (diagnostic.severity !== undefined && SEVERITY_LABELS[diagnostic.severity]) ?? "unknown";
     const severityColor = severityLabel === "error" ? COLORS.error : COLORS.warning;
 
+    const message =
+        typeof diagnostic.message === "string" ? diagnostic.message : diagnostic.message.value;
+
     return (
         PADDING +
         [
             COLORS.gray(position),
             severityColor(severityLabel),
-            diagnostic.message,
+            message,
             diagnostic.code !== undefined ? COLORS.gray(diagnostic.code) : "",
         ]
             .filter(Boolean)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "oxlint-tsgolint": "0.23.0",
         "semantic-release": "25.0.3",
         "typescript": "6.0.3",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-languageserver-types": "3.18.0"
     },
     "devEngines": {
         "packageManager": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,8 +254,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       vscode-languageserver-types:
-        specifier: 3.17.5
-        version: 3.17.5
+        specifier: 3.18.0
+        version: 3.18.0
 
 packages:
 
@@ -2269,6 +2269,9 @@ packages:
 
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
   web-tree-sitter@0.24.5:
     resolution: {integrity: sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==}
@@ -4369,6 +4372,8 @@ snapshots:
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
 
   web-tree-sitter@0.24.5: {}
 


### PR DESCRIPTION
## Summary

Fixes the CI failure on PR #83 (Renovate's `vscode-languageserver-types` 3.17.5 → 3.18.0 update).

## Why #83 was failing

Only the `lint` (oxlint) step of the `check` job was failing.

The cause is a type change in `Diagnostic.message` in 3.18.0:

| Version | Type of `Diagnostic.message` |
|---|---|
| 3.17.5 | `string` |
| 3.18.0 | `string \| MarkupContent` |

`MarkupContent` is an object (`{ kind, value }`). In `formatDiagnostic` (`bin/lib.mjs`), passing `diagnostic.message` straight into the array and calling `.join()` could stringify an object as `[object Object]`, which oxlint's type-aware rule (`no-base-to-string` / oxlint-tsgolint) flags as an error.

## Changes

- Bump `vscode-languageserver-types` to 3.18.0 (same as #83)
- In `formatDiagnostic`, extract `.value` when `message` is a `MarkupContent` object

```js
const message =
    typeof diagnostic.message === "string" ? diagnostic.message : diagnostic.message.value;
```

## Verification

Confirmed locally that `pnpm run check` (typecheck / lint / format / test) all pass.

Once this PR is merged, #83 can be closed.

https://claude.ai/code/session_01DifTgjQYn5UDt6WdTdr6Gs